### PR TITLE
Increase max `readUInt64LE` constraint

### DIFF
--- a/src/bufferutils.js
+++ b/src/bufferutils.js
@@ -57,7 +57,7 @@ function readUInt64LE (buffer, offset) {
   var b = buffer.readUInt32LE(offset + 4)
   b *= 0x100000000
 
-  verifuint(b + a, 0x001fffffffffffff)
+  verifuint(b + a, 0xffffffffffffffff)
 
   return b + a
 }

--- a/src/bufferutils.js
+++ b/src/bufferutils.js
@@ -120,7 +120,7 @@ function writePushDataInt (buffer, number, offset) {
 }
 
 function writeUInt64LE (buffer, value, offset) {
-  verifuint(value, 0x001fffffffffffff)
+  verifuint(value, 0xffffffffffffffff)
 
   buffer.writeInt32LE(value & -1, offset)
   buffer.writeUInt32LE(Math.floor(value / 0x100000000), offset + 4)

--- a/test/fixtures/bufferutils.json
+++ b/test/fixtures/bufferutils.json
@@ -83,22 +83,7 @@
     }
   ],
   "invalid": {
-    "readUInt64LE": [
-      {
-        "description": "n === 2^53",
-        "exception": "value is larger than maximum value for type",
-        "hex64": "0000000000002000",
-        "hexVI": "ff0000000000000020",
-        "dec": 9007199254740992
-      },
-      {
-        "description": "n > 2^53",
-        "exception": "value is larger than maximum value for type",
-        "hex64": "0100000000002000",
-        "hexVI": "ff0100000000000020",
-        "dec": 9007199254740993
-      }
-    ],
+    "readUInt64LE": [],
     "readPushDataInt": [
       {
         "description": "OP_PUSHDATA1, no size",


### PR DESCRIPTION
In order to parse voxel transactions this constraint must be lifted.

R=@nunofgs 
